### PR TITLE
Update go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module dsieve
+module github.com/trickest/dsieve
 
 go 1.18
 


### PR DESCRIPTION
Updated go.mod for installing conventions, currently trying to install dsieve with `go install github.com/trickest/dsieve` produces:

```
go: github.com/trickest/dsieve@latest: github.com/trickest/dsieve@v1.0.1: parsing go.mod:
        module declares its path as: dsieve
                but was required as: github.com/trickest/dsieve
```