### PR TITLE
Handle domain names starting with http or https

### DIFF
--- a/dsieve.go
+++ b/dsieve.go
@@ -79,7 +79,7 @@ func writeResults(domains *[]string) {
 
 func parseUrl(rawUrl string, lMin, lMax int) []string {
 	domains := make([]string, 0)
-	if !strings.HasPrefix(rawUrl, "http") {
+	if !strings.HasPrefix(rawUrl, "http://") && !strings.HasPrefix(rawUrl, "https://") {
 		rawUrl = "http://" + rawUrl
 	}
 	u, err := url.Parse(rawUrl)


### PR DESCRIPTION
parseUrl() does not work for domain names like `httpanywhere.com` or `httpsanywhere.com`.

This patch checks if `http` or `https` is followed by `://`.